### PR TITLE
Automated tagging at the Docker hub/store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN \
 	/tmp/s6-overlay.tar.gz -C / && \
 
  cd tmp && \
- wget -q http://downloads.rclone.org/rclone-${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
+ wget -q http://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
  unzip /tmp/rclone-${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
  mv /tmp/rclone-*-linux-${PLATFORM_ARCH}/rclone /usr/bin && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG RCLONE_VERSION="current"
 FROM alpine:latest
 MAINTAINER tynor88 <tynor@hotmail.com>
 
 # global environment settings
 ENV PLATFORM_ARCH="amd64"
+ARG RCLONE_VERSION="current"
 
 # s6 environment settings
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
@@ -18,27 +18,23 @@ RUN \
 # install build packages
 RUN \
  apk add --no-cache --virtual=build-dependencies \
- wget \
- curl \
- unzip && \
- 
+		wget \
+		curl \
+		unzip && \
 # add s6 overlay
  OVERLAY_VERSION=$(curl -sX GET "https://api.github.com/repos/just-containers/s6-overlay/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
  curl -o \
- /tmp/s6-overlay.tar.gz -L \
+	/tmp/s6-overlay.tar.gz -L \
 	"https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${PLATFORM_ARCH}.tar.gz" && \
  tar xfz \
 	/tmp/s6-overlay.tar.gz -C / && \
-
  cd tmp && \
- wget -q http://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
- unzip /tmp/rclone-${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
+ wget -q https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
+ unzip /tmp/rclone-v${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
  mv /tmp/rclone-*-linux-${PLATFORM_ARCH}/rclone /usr/bin && \
-
  apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/community \
 	shadow && \
-
 # cleanup
  apk del --purge \
 	build-dependencies && \
@@ -52,7 +48,6 @@ RUN \
 	groupmod -g 1000 users && \
 	useradd -u 911 -U -d /config -s /bin/false abc && \
 	usermod -G users abc && \
-
 # create some files / folders
 	mkdir -p /config /app /defaults /data && \
 	touch /var/lock/rclone.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
+ARG RCLONE_VERSION="current"
 FROM alpine:latest
 MAINTAINER tynor88 <tynor@hotmail.com>
 
 # global environment settings
-ENV RCLONE_VERSION="current"
 ENV PLATFORM_ARCH="amd64"
 
 # s6 environment settings

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RCLONE_REPO="ncw/rclone"
+RELEASES=$(curl -qsL https://api.github.com/repos/${RCLONE_REPO}/tags | grep \"name\"|sed "s/^ *\"name\" *: *\"v\(\([0-9]\+\.\)\+[0-9]\+\\)\" *,/\1/g")
+
+IMG=$(basename $DOCKER_REPO)
+for tag in ${RELEASES}; do
+    echo "============== Building ${IMG}:$tag"
+    docker build --build-arg RCLONE_VERSION=$tag -t ${DOCKER_REPO}:$tag .
+done

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RCLONE_REPO="ncw/rclone"
+RELEASES=$(curl -qsL https://api.github.com/repos/${RCLONE_REPO}/tags | grep \"name\"|sed "s/^ *\"name\" *: *\"v\(\([0-9]\+\.\)\+[0-9]\+\\)\" *,/\1/g")
+
+IMG=$(basename $DOCKER_REPO)
+for tag in ${RELEASES}; do
+    echo "============== Pushing ${IMG}:$tag"
+    docker push ${DOCKER_REPO}:$tag .
+done

--- a/hooks/push
+++ b/hooks/push
@@ -6,5 +6,5 @@ RELEASES=$(curl -qsL https://api.github.com/repos/${RCLONE_REPO}/tags | grep \"n
 IMG=$(basename $DOCKER_REPO)
 for tag in ${RELEASES}; do
     echo "============== Pushing ${IMG}:$tag"
-    docker push ${DOCKER_REPO}:$tag .
+    docker push ${DOCKER_REPO}:$tag
 done


### PR DESCRIPTION
This uses a `hooks` directory to automatically create one Docker image per known and official version of rclone. The available version numbers are automatically got from the [releases](https://github.com/ncw/rclone/releases) using the github api for [tags](https://developer.github.com/v3/repos/#list-tags). You can see the result on my [version](https://hub.docker.com/r/efrecon/rclone/tags/) at the hub, an image that is just set up as an automated build and bound to my github fork.