### PR TITLE
Use environment variable for user and group id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV S6_KEEP_ENV=1
 
 # User and Group ID
 ENV PUID=911
-ENV GUID=1000
+ENV PGID=1000
 
 # install packages
 RUN \
@@ -49,7 +49,7 @@ RUN \
 
 # create abc user
 RUN \
-	groupmod -g ${GUID} users && \
+	groupmod -g ${PGID} users && \
 	useradd -u ${PUID} -U -d /config -s /bin/false abc && \
 	usermod -G users abc && \
 # create some files / folders

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ARG RCLONE_VERSION="current"
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 ENV S6_KEEP_ENV=1
 
+# User and Group ID
+ENV PUID=911
+ENV GUID=1000
+
 # install packages
 RUN \
  apk update && \
@@ -45,8 +49,8 @@ RUN \
 
 # create abc user
 RUN \
-	groupmod -g 1000 users && \
-	useradd -u 911 -U -d /config -s /bin/false abc && \
+	groupmod -g ${GUID} users && \
+	useradd -u ${PUID} -U -d /config -s /bin/false abc && \
 	usermod -G users abc && \
 # create some files / folders
 	mkdir -p /config /app /defaults /data && \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ docker create \
 * `-e SYNC_DESTINATION_SUBPATH` If the data should be backed up to a subpath on the destionation (will automaticly be created if it does not exist)
 * `-e CRON_SCHEDULE` A custom cron schedule which will override the default value of: 0 * * * * (hourly)
 * `-e SYNC_COMMAND` A custom rclone command which will override the default value of: rclone sync /data $SYNC_DESTINATION:/$SYNC_DESTINATION_SUBPATH
-
+* `-e PUID` User id
+* `-e PGID` Group id
 
 ## Info
 


### PR DESCRIPTION
I added environment variables for User and Group ID so these can be specified in a docker compose file. This can help resolve permission issues.