### PR TITLE
Update Rclone and C6 overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:latest
-MAINTAINER tynor88 <tynor@hotmail.com>
+LABEL org.opencontainers.image.authors="tynor88 <tynor@hotmail.com>"
 
 # global environment settings
-ENV PLATFORM_ARCH="amd64"
+ENV S6_ARC="x86_64"
+ENV RCLONE_PLATFORM_ARCH="amd64"
 ARG RCLONE_VERSION="current"
 
 # s6 environment settings
@@ -11,34 +12,49 @@ ENV S6_KEEP_ENV=1
 
 # install packages
 RUN \
- apk update && \
- apk add --no-cache \
- ca-certificates
+	apk update && \
+	apk add --no-cache \
+	ca-certificates
 
 # install build packages
 RUN \
- apk add --no-cache --virtual=build-dependencies \
-		wget \
-		curl \
-		unzip && \
+ 	apk add --no-cache --virtual=build-dependencies \
+	wget \
+	curl \
+	jq \
+	unzip && \
 # add s6 overlay
- OVERLAY_VERSION=$(curl -sX GET "https://api.github.com/repos/just-containers/s6-overlay/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]') && \
- curl -o \
-	/tmp/s6-overlay.tar.gz -L \
-	"https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${PLATFORM_ARCH}.tar.gz" && \
- tar xfz \
-	/tmp/s6-overlay.tar.gz -C / && \
- cd tmp && \
- wget -q https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
- unzip /tmp/rclone-v${RCLONE_VERSION}-linux-${PLATFORM_ARCH}.zip && \
- mv /tmp/rclone-*-linux-${PLATFORM_ARCH}/rclone /usr/bin && \
- apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+	S6_OVERLAY_VERSION=$(curl -s https://api.github.com/repos/just-containers/s6-overlay/releases/latest | jq -r .tag_name) && \
+    echo "Latest S6 Overlay version: $S6_OVERLAY_VERSION" && \
+    # Download and install the latest s6-overlay. All legacy tarballs are required.
+    curl -L "https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/s6-overlay-noarch.tar.xz" -o /tmp/s6-overlay-noarch.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
+    curl -L "https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/s6-overlay-${S6_ARC}.tar.xz" -o /tmp/s6-overlay-${S6_ARC}.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-${S6_ARC}.tar.xz && \
+	curl -L "https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/s6-overlay-symlinks-noarch.tar.xz" -o /tmp/s6-overlay-symlinks-noarch.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz && \
+	curl -L "https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/s6-overlay-symlinks-arch.tar.xz" -o /tmp/s6-overlay-symlinks-arch.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz && \
+	curl -L "https://github.com/just-containers/s6-overlay/releases/download/$S6_OVERLAY_VERSION/syslogd-overlay-noarch.tar.xz" -o /tmp/syslogd-overlay-noarch.tar.xz && \
+    tar -C / -Jxpf /tmp/syslogd-overlay-noarch.tar.xz && \
+ 	cd tmp && \
+# add rclone
+	if [ "$RCLONE_VERSION" = "current" ]; then \
+		echo "RCLONE_VERSION is set to 'current'." && \
+		wget -q https://downloads.rclone.org/rclone-current-linux-${RCLONE_PLATFORM_ARCH}.zip && \
+		unzip /tmp/rclone-current-linux-${RCLONE_PLATFORM_ARCH}.zip; \
+	else \
+		echo "RCLONE_VERSION is not set to 'current'. It is set to '$RCLONE_VERSION'." && \
+		wget -q https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-${RCLONE_PLATFORM_ARCH}.zip && \
+		unzip /tmp/rclone-v${RCLONE_VERSION}-linux-${RCLONE_PLATFORM_ARCH}.zip; \
+	fi && \
+	mv /tmp/rclone-*-linux-${RCLONE_PLATFORM_ARCH}/rclone /usr/bin && \
+	apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 	shadow && \
 # cleanup
- apk del --purge \
+ 	apk del --purge \
 	build-dependencies && \
- rm -rf \
+ 	rm -rf \
 	/tmp/* \
 	/var/tmp/* \
 	/var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -13,29 +13,112 @@
 Docker for [Rclone][appurl] - a command line program to sync files and directories to and from various cloud services.
 
 **Cloud Services**
-* Google Drive
+* 1Fichier
+* Akamai Netstorage
+* Alibaba Cloud (Aliyun) Object Storage System (OSS)
 * Amazon S3
-* Openstack Swift / Rackspace cloud files / Memset Memstore
-* Dropbox
-* Google Cloud Storage
-* Amazon Drive
-* Microsoft One Drive
-* Hubic
 * Backblaze B2
+* Box
+* Ceph
+* China Mobile Ecloud Elastic Object Storage (EOS)
+* Arvan Cloud Object Storage (AOS)
+* Citrix ShareFile
+* Cloudflare R2
+* Cloudinary
+* DigitalOcean Spaces
+* Digi Storage
+* Dreamhost
+* Dropbox
+* Enterprise File Fabric
+* Fastmail Files
+* Files.com
+* FTP
+* Gofile
+* Google Cloud Storage
+* Google Drive
+* Google Photos
+* HDFS
+* Hetzner Storage Box
+* HiDrive
+* HTTP
+* iCloud Drive
+* ImageKit
+* Internet Archive
+* Jottacloud
+* IBM COS S3
+* IDrive e2
+* IONOS Cloud
+* Koofr
+* Leviia Object Storage
+* Liara Object Storage
+* Linkbox
+* Linode Object Storage
+* Magalu
+* Mail.ru Cloud
+* Memset Memstore
+* Mega
+* Memory
+* Microsoft Azure Blob Storage
+* Microsoft Azure Files Storage
+* Microsoft OneDrive
+* Minio
+* Nextcloud
+* OVH
+* Blomp Cloud Storage
+* OpenDrive
+* OpenStack Swift
+* Oracle Cloud Storage Swift
+* Oracle Object Storage
+* Outscale
+* ownCloud
+* pCloud
+* Petabox
+* PikPak
+* Pixeldrain
+* premiumize.me
+* put.io
+* Proton Drive
+* QingStor
+* Qiniu Cloud Object Storage (Kodo)
+* Quatrix by Maytech
+* Rackspace Cloud Files
+* rsync.net
+* Scaleway
+* Seafile
+* Seagate Lyve Cloud
+* SeaweedFS
+* Selectel
+* SFTP
+* Sia
+* SMB / CIFS
+* StackPath
+* Storj
+* Synology
+* SugarSync
+* Tencent Cloud Object Storage (COS)
+* Uloz.to
+* Uptobox
+* Wasabi
+* WebDAV
 * Yandex Disk
+* Zoho WorkDrive
 * The local filesystem
 
 **Features**
-
-* MD5/SHA1 hashes checked at all times for file integrity
-* Timestamps preserved on files
-* Partial syncs supported on a whole file basis
-* Copy mode to just copy new/changed files
-* Sync (one way) mode to make a directory identical
-* Check mode to check for file hash equality
-* Can sync to and from network, eg two different cloud accounts
-* Optional encryption (Crypt)
-* Optional FUSE mount (rclone mount) - **See [docker-rclone-mount][docker-rclone-mount]**
+* Transfers
+  * MD5, SHA1 hashes are checked at all times for file integrity
+  * Timestamps are preserved on files
+  * Operations can be restarted at any time
+  * Can be to and from network, e.g. two different cloud providers
+  * Can use multi-threaded downloads to local disk
+* Copy new or changed files to cloud storage
+* Sync (one way) to make a directory identical
+* Bisync (two way) to keep two directories in sync bidirectionally
+* Move files to cloud storage deleting the local after verification
+* Check hashes and for missing/extra files
+* Mount your cloud storage as a network disk
+* Serve local or remote files over HTTP/WebDav/FTP/SFTP/DLNA
+* Experimental Web based GUI
 
 ## Usage
 
@@ -67,6 +150,8 @@ docker create \
 
 ## Versions
 
++ **2024/01/12:**
+  * Updated to latest Rclone(v1.38) and s6-overlay(v3.2.0.2)
 + **2017/10/15:**
   * Update to latest Rclone (v1.38)
 + **2017/01/25:**


### PR DESCRIPTION
**Problem addressed in PR**
The structure of the download links for both Rclone and c6-overlay have changed breaking the docker builds. This leaves the image stuck on an ancient version of Rclone which uses and older version of Oauth that is no longer supported by many providers.

This PR updates the Dockerfile to use the new download links for both Rclone and c6-overlay while attempting to preserve the original build behavior to avoid breaking the build pipeline. 

**Changes**
- update dockerfile to get latest version of Rclone using the new download urls 
- update dockerfile to get latest version of c6-overlay using new download urls 
- fix deprecated MAINTAINER command in Dockerfile
- add s6-overlay arc env to support new download urls
- update readme to match latest Rclone documentation

**Testing**
Tested docker build and running the container with a configured .rclone.conf. New container is able to sync to google drive successfully

Image available at https://hub.docker.com/r/nathansupinski/docker-rclone